### PR TITLE
fix README for step05

### DIFF
--- a/step05/README.md
+++ b/step05/README.md
@@ -73,7 +73,7 @@ func printScreen() {
     // code omitted...
 
     // print score
-    moveCursor(len(maze)+1, 0)
+    simpleansi.MoveCursor(len(maze)+1, 0)
     fmt.Println("Score:", score, "\tLives:", lives)
 }
 ```


### PR DESCRIPTION
the `moveCursor` method is not yet introduced in step05. 