### PR TITLE
Update README.md within Step 10

### DIFF
--- a/step10/README.md
+++ b/step10/README.md
@@ -137,7 +137,7 @@ Another possible race condition that might arise during execution is when we upd
 ```go 
 var ghostsStatusMx sync.RWMutex
 
-func updateGhosts(ghosts []*Ghost, ghostStatus GhostStatus) {
+func updateGhosts(ghosts []*ghost, ghostStatus GhostStatus) {
 	ghostsStatusMx.Lock()
 	defer ghostsStatusMx.Unlock()
 	for _, g := range ghosts {


### PR DESCRIPTION
## Change Summary

- Updated the type within the `README.md` from `ghosts []*Ghost` to `ghosts []*ghost`, which was a typo error
- This was done to have a valid type, and keep the `README.md` and `step10/main.go` consistent

## Other Notes

Intends to close Issue https://github.com/danicat/pacgo/issues/43#issue-2201210728